### PR TITLE
Fix integer overflow bug when comparing large files/directories

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -5128,6 +5128,7 @@ size_column_sort_func (GtkTreeModel *model,
 	FileData    *fdata2;
 	GtkSortType  sort_order;
 	int          result;
+	goffset      size_difference;
 
 	gtk_tree_sortable_get_sort_column_id (GTK_TREE_SORTABLE (model), NULL, &sort_order);
 
@@ -5136,9 +5137,10 @@ size_column_sort_func (GtkTreeModel *model,
 
 	if (file_data_is_dir (fdata1) == file_data_is_dir (fdata2)) {
         	if (file_data_is_dir (fdata1))
-                	result = fdata1->dir_size - fdata2->dir_size;
+			size_difference = fdata1->dir_size - fdata2->dir_size;
         	else
-        		result = fdata1->size - fdata2->size;
+			size_difference = fdata1->size - fdata2->size;
+		result = (size_difference > 0) - (size_difference < 0);
         }
         else {
         	result = file_data_is_dir (fdata1) ? -1 : 1;


### PR DESCRIPTION
Storing the file/directory size difference in a 32bit signed integer resulted in a wrong sorting order for large files/directories. This commit fixes the bug by first storing the size difference in a variable with the same type as FileData->size and FileData->dir_size (goffset) and calculating the sort_func return value as sign of the file size difference (size_difference>0 <=> result=1, size_difference=0 <=> result=0, size_difference<0 <=> result=-1).
