### PR TITLE
Add UI option to extract into a wrapper directory based on the archive name

### DIFF
--- a/data/org.gnome.FileRoller.gschema.xml
+++ b/data/org.gnome.FileRoller.gschema.xml
@@ -158,6 +158,10 @@
       <default>true</default>
       <summary>Recreate the folders stored in the archive</summary>
     </key>
+    <key name="create-parent" type="b">
+      <default>false</default>
+      <summary>Create a wrapper directory for the archive before extracting</summary>
+    </key>
   </schema>
 
   <schema id="org.gnome.FileRoller.Dialogs.New" path="/org/gnome/file-roller/dialogs/new/" gettext-domain="file-roller">

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -56,6 +56,7 @@
 
 #define PREF_EXTRACT_SKIP_NEWER           "skip-newer"
 #define PREF_EXTRACT_RECREATE_FOLDERS     "recreate-folders"
+#define PREF_EXTRACT_CREATE_PARENT        "create-parent"
 
 #define PREF_ADD_CURRENT_FOLDER           "current-folder"
 #define PREF_ADD_SELECTED_FILES           "selected-files"

--- a/src/ui/extract-dialog-options.ui
+++ b/src/ui/extract-dialog-options.ui
@@ -194,6 +194,23 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkCheckButton" id="create_parent_checkbutton">
+                <property name="label" translatable="yes">_Create wrapper directory</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Archives created on other OSs often have a lot of files and directories in the base of the archive, with the assumption that they'll be extracted with the same tool, which autocreates a base folder before extraction.

This PR adds an option to mimic the assumed extraction behavior.

It _is_ obviously possible to just create the folder during destination selection, but when you're constantly  extracting archives like `foo_bar_baz-abc123.zip`, creating folders like `foo_bar_baz-abc123` from the UI becomes extremely tedious.

I see there's a similar patch (from 2010!) at https://bugzilla.gnome.org/show_bug.cgi?id=614806 , which is heavily bitrotted by now.