### PR TITLE
Reprioritized folders to go for tmp before .cache

### DIFF
--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -48,7 +48,7 @@
 /* path */
 
 
-static const char *try_folder[] = { "cache", "~", "tmp", NULL };
+static const char *try_folder[] = {"tmp", "cache", "~",  NULL };
 
 
 static const char *


### PR DESCRIPTION
I came across this thread on Reddit:
https://old.reddit.com/r/linux/comments/12fcqo3/gnome_archive_manager_also_known_as_file_roller/

In it, a user points out that File Roller is creating directories that are not being cleaned up. They also mention that it is frustrating for the directories to be simply named ".fr-" since fr is not obviously associated with File Roller.

That being said, the lack of cleanup and the unclear naming are their own problems which take a bit more effort. For now, I've rearranged the priority so that the software will attempt to store these temporary extracted directories in /tmp so that the operating system will automatically clean them up in the event that they get left behind. This will hopefully eliminate the issue with cluttering `.cache`.